### PR TITLE
Fix CloudConvert::Webhook::Processor method `name` not implemented

### DIFF
--- a/lib/cloudconvert/webhook/processor.rb
+++ b/lib/cloudconvert/webhook/processor.rb
@@ -11,7 +11,7 @@ module CloudConvert::Webhook::Processor
 
   def create
     method = event.name.gsub(".", "_")
-    raise NoMethodError.new("#{name}##{method} not implemented") unless respond_to?(method, true)
+    raise NoMethodError.new("#{self.class.name}##{method} not implemented") unless respond_to?(method, true)
     send(method, event)
     head(:ok)
   end

--- a/spec/webhook/processor_spec.rb
+++ b/spec/webhook/processor_spec.rb
@@ -80,7 +80,7 @@ describe CloudConvert::Webhook::Processor, :unit do
       let(:controller) { ControllerWithoutMethod.new(request) }
 
       it "raises an error" do
-        expect { controller.create }.to raise_error NoMethodError
+        expect { controller.create }.to raise_error(NoMethodError, "ControllerWithoutMethod#job_finished not implemented")
       end
     end
 


### PR DESCRIPTION
Fixes this error message by removing calling `name` which is undefined in this context.

Example Rails log output w/out this fix:

```
[cb586f7a-2e32-4585-8e3a-dcef4c907323] NameError (undefined local variable or method `name' for #<CloudConvertWebhooksController:0x000000000b7b60>):
[cb586f7a-2e32-4585-8e3a-dcef4c907323]
[cb586f7a-2e32-4585-8e3a-dcef4c907323] lib/invalid_mime_type_error_handler_middleware.rb:7:in `call'
```